### PR TITLE
feat(test): Adds test configurations for Karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,69 @@
+// Karma configuration
+// Generated on Wed Jul 08 2015 09:28:26 GMT-0700 (PDT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'requirejs'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'test-main.js',
+      {pattern: 'node_modules/chai/chai.js', included: false},
+      {pattern: 'node_modules/rx/dist/rx.all.js', included: false},
+      {pattern: 'dist/**/src/*.js', included: false},
+      {pattern: 'dist/**/test/*.js', included: false}
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['dots'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['ChromeCanary'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  })
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,12 @@
     "gulp-clean": "^0.3.1",
     "gulp-mocha": "^2.1.2",
     "gulp-typescript": "^2.7.6",
+    "karma": "^0.12.37",
+    "karma-chrome-launcher": "^0.2.0",
+    "karma-mocha": "^0.2.0",
+    "karma-requirejs": "^0.2.2",
     "mocha": "^2.2.5",
+    "requirejs": "^2.1.18",
     "run-sequence": "^1.1.1",
     "tsd": "^0.6.0",
     "typescript": "alexeagle/TypeScript#error_is_class"

--- a/test-main.js
+++ b/test-main.js
@@ -1,0 +1,30 @@
+var allTestFiles = [];
+var TEST_REGEXP = /(spec|test)\.js$/i;
+
+// Get a list of all the test files to include
+Object.keys(window.__karma__.files).forEach(function(file) {
+  if (TEST_REGEXP.test(file)) {
+    // Normalize paths to RequireJS module names.
+    // If you require sub-dependencies of test files to be loaded as-is (requiring file extension)
+    // then do not normalize the paths
+    var normalizedTestModule = file.replace(/^\/base\/|\.js$/g, '');
+    allTestFiles.push(normalizedTestModule);
+  }
+});
+
+require.config({
+  // Karma serves files under /base, which is the basePath from your config file
+  baseUrl: '/base',
+  
+  // Module paths (included in Karma files) that are not found in dist
+  paths: {
+    'chai': 'node_modules/chai/chai',
+    'rx': 'node_modules/rx/dist/rx.all'
+  },
+
+  // dynamically load all test files
+  deps: allTestFiles,
+
+  // we have to kickoff jasmine, as it is asynchronous
+  callback: window.__karma__.start
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-    "version": "1.5.0",
     "compilerOptions": {
         "target": "es5",
         "module": "commonjs",


### PR DESCRIPTION
Allows all specs to be run in browser using the 'test.karma' task. In order to run specs in browser, all ts files must be compiled to 'amd' format. The 'build.karma' task takes care of replacing all 'commonjs' files in dist with 'amd' files.