### PR TITLE
fix(store): Randomly generates sub version ids for mutations.

### DIFF
--- a/modules/tactical/src/tactical_store.ts
+++ b/modules/tactical/src/tactical_store.ts
@@ -103,6 +103,11 @@ export class Version {
   private _value: PlainVersion;
   private _serial: string;
 
+  /** Returns a randomly generated integer id in the range of 1 to 2**32 (exclusive). */
+  private static _randomId(): number {
+    return Math.floor(Math.random() * (Math.pow(2, 32) - 1)) + 1;
+  }
+
   /** Returns a new Version instance with the same base and sub as 'version'. */
   static from(version: PlainVersion): Version { return new Version(version.base, version.sub); }
 
@@ -127,7 +132,7 @@ export class Version {
   get initial(): Version { return new Version(this.base); }
 
   /** Returns the next sub version associated with this Version. */
-  get next(): Version { return new Version(this.base, this.sub + 1); }
+  get next(): Version { return new Version(this.base, Version._randomId()); }
 
   /** Returns the base version. */
   get base(): string { return this._value.base; }

--- a/modules/tactical/test/tactical_store_spec.ts
+++ b/modules/tactical/test/tactical_store_spec.ts
@@ -43,8 +43,6 @@ describe("Tactical Store", () => {
           return ts.fetch(key);
         })
         .subscribeOnNext((record: Record) => {
-          var mutation: Version = new Version(foobase).next;
-          expect(record.version.isEqual(mutation.base, mutation.sub)).to.be.true;
           expect(record.value['value']).to.equal('foobaz');
           done();
         });
@@ -171,8 +169,6 @@ describe("Tactical Store", () => {
           return ts.commit(key, foobaz, new Version(foobase));
         })
         .subscribe((record: Record) => {
-          var mutation: Version = new Version(foobase).next;
-          expect(record.version.isEqual(mutation.base, mutation.sub)).to.be.true;
           expect(record.value['value']).to.equal('foobaz');
           done();
         });
@@ -311,8 +307,6 @@ describe("Tactical Store", () => {
           return ts.pending();
         })
         .subscribeOnNext((record: Record) => {
-          var mutversion: Version = new Version(foobase).next;
-          expect(record.version.isEqual(mutversion.base, mutversion.sub)).to.be.true;
           expect(record.value['value']).to.equal('foobaz');
           done();
         });


### PR DESCRIPTION
Fixes bug where two competing clients could submit mutations, with the same base and sub version, whose object values were not the same.