### PR TITLE
refactor(store): Cleans up Store methods to make them more concise.

### DIFF
--- a/modules/tactical/src/data_manager.ts
+++ b/modules/tactical/src/data_manager.ts
@@ -55,8 +55,8 @@ export class TacticalDataManager implements DataManager {
    */
   private _backendData(data: VersionedObject): void {
     var keyStr = serializeValue(data.key);
-    this._store.push(data.key, data.data, data.version).subscribe();
-    this._pushUpdate(keyStr, new Record(data.data, new Version(data.version)));
+    this._store.push(data.key, data.version, data.data).subscribe();
+    this._pushUpdate(keyStr, new Record(new Version(data.version), data.data));
   }
 
   /**
@@ -71,13 +71,7 @@ export class TacticalDataManager implements DataManager {
   }
 
   commit(key: Object, value: Object, baseVersion: Version): Observable<boolean> {
-    return this._store.commit(key, value, baseVersion)
-        .map((record: Record): boolean => {
-          if (record != null) {
-            this._pushUpdate(serializeValue(key), record);
-          }
-          return (record != null);
-        });
+    return this._store.commit(key, baseVersion, value, {}).defaultIfEmpty().map(() => true);
   }
 
   _open(key: Object, keyStr: string): Observable<Record> {

--- a/modules/tactical/src/idb.ts
+++ b/modules/tactical/src/idb.ts
@@ -126,7 +126,7 @@ export class InMemoryIdb implements Idb {
     return Observable.just<IdbTransaction>(new InMemoryTransaction(this.db),
                                            Scheduler.currentThread);
   }
-  
+
   _clone(value: Object): Object {
     if (value === null || value === undefined) {
       return value;

--- a/modules/tactical/src/tactical_store.ts
+++ b/modules/tactical/src/tactical_store.ts
@@ -17,7 +17,7 @@
  * each combination should identify a single Record.
  */
 
-import {Observable, Scheduler} from 'rx';
+import {Observable, Subject, Scheduler} from 'rx';
 
 import {Idb, IdbFactory, IdbTransaction} from './idb';
 import {serializeValue} from './json';
@@ -26,29 +26,36 @@ import {serializeValue} from './json';
 //==================================================================================================
 
 /**
- * An explicit type to maintain versioning across a Chain that can be concisely stored in
- * cache. Implementations should be plain JS objects.
+ * Maintains stateful information about each Chain. Each State contains a set of references to
+ * Records currently persisted in cache.
+ */
+export interface ChainState {
+  current: PlainVersion;     // a reference to the most recent Record stored in cache
+  outdated: PlainVersion[];  // a list of old mutated versions that haven't been resolved by the
+                             // application
+}
+
+/**
+ * Maintains contextual information associated with each Record that is persisted in cache.
+ */
+export interface Entry {
+  context: Object;  // the contextual data associated with the Record
+  value: Object;    // the value of the Record
+}
+
+/**
+ * Maintains versioning across a Chain.
  */
 export interface PlainVersion {
   base: string;  // a string provided by the backend to uniquely identify the version
   sub: number;   // the iteration of 'base' currently persisted in cache
 }
 
-/**
- * An explicit type to maintain stateful information about each Chain. Each State contains a set of
- * references to Records currently persisted in cache. Implementations should be plain JS objects.
- */
-export interface ChainState {
-  current: PlainVersion;     // a reference to the most recent Record stored in cache
-  backup: PlainVersion;      // a duplicate of 'current' to protect against failed writes
-  deprecated: PlainVersion;  // an old mutated version that hasn't been resolved by the application
-}
-
 // Key classes used to persist objects in cache.
 //==================================================================================================
 
 /**
- * A wrapper class to handle serializing keys to identify a Chain.
+ * Handles serializing keys to identify a Chain.
  */
 export class ChainKey {
   private _serial: string;
@@ -57,6 +64,7 @@ export class ChainKey {
   constructor(private _key: Object | string) {
     if (typeof this._key == 'string') {
       this._serial = <string>this._key;
+      this._key = JSON.parse(<string>this._key);
     } else {
       this._serial = serializeValue(this._key);
     }
@@ -70,7 +78,7 @@ export class ChainKey {
 }
 
 /**
- * A wrapper class to handle serializing keys to identify a Record.
+ * Handles serializing keys to identify a Record.
  */
 export class RecordKey {
   private _serial: string;
@@ -83,33 +91,69 @@ export class RecordKey {
   /** Returns the provided ChainKey. */
   get chain(): ChainKey { return this._key; }
 
-  /** Returns the provided Version. */
-  get version(): Version { return this._version; }
-
   /**
    * Returns the serialization of the RecordKey. A RecordKey is only serialized at instantiation.
    * The ChainKey and Version are not reserialized.
    */
   get serial(): string { return this._serial; }
+
+  /** Returns the provided Version. */
+  get version(): Version { return this._version; }
 }
 
 // Classes intended to be emitted by Store instances.
 //==================================================================================================
 
 /**
- * A wrapper class to provide methods Tactical Store can use to maintain versioning.
+ * Contains the information necessary to resolve an outdated mutation.
+ */
+export class OutdatedMutation {
+  /**
+   * Contains the associated 'key' object, a Record of the 'current' version in the Store, a Record
+   * of
+   * the outdated 'mutation', and a Record of the 'initial' version of the 'mutation'.
+   */
+  constructor(public key: Object, public current: Record, public mutation: Record,
+              public initial: Record) {}
+}
+
+/**
+ * Contains the information necessary to resolve a pending mutation.
+ */
+export class PendingMutation {
+  /**
+   * Contains the associated 'key' object, and a Record of the pending 'mutation'.
+   */
+  constructor(public key: Object, public mutation: Record) {}
+}
+
+/**
+ * A Record is a version of an object persisted in cache and identified by a single
+ * combination of a key and a Version. The key identifies the Chain of Records for a single object
+ * and the Version identifies the particular Record of that object.
+ */
+export class Record {
+  /**
+   * Contains the 'version' of the Record, the 'value' associated with that 'version', and 'context'
+   * information associated with that 'version'.
+   */
+  constructor(public version: Version, public value: Object, public context: Object = {}) {}
+}
+
+/**
+ * Maintains versioning for the Store.
  */
 export class Version {
   private _value: PlainVersion;
   private _serial: string;
 
+  /** Returns a new Version instance with the same base and sub as 'version'. */
+  static from(version: PlainVersion): Version { return new Version(version.base, version.sub); }
+
   /** Returns a randomly generated integer id in the range of 1 to 2**32 (exclusive). */
   private static _randomId(): number {
     return Math.floor(Math.random() * (Math.pow(2, 32) - 1)) + 1;
   }
-
-  /** Returns a new Version instance with the same base and sub as 'version'. */
-  static from(version: PlainVersion): Version { return new Version(version.base, version.sub); }
 
   /**
    * Instantiates a new Version object matching the 'base' and 'sub' version. If 'sub' is not
@@ -120,22 +164,20 @@ export class Version {
     this._serial = serializeValue(this._value);
   }
 
-  /** Returns true if this Version has a matching 'base' and (if provided) 'sub' version */
-  isEqual(base: string, sub?: number): boolean {
-    return (sub) ? this.base == base && this.sub == sub : this.base == base;
-  }
-
-  /** Returns true if the Version is an intitial sub version. */
-  get isInitial(): boolean { return this.sub == 0; }
+  /** Returns the base version. */
+  get base(): string { return this._value.base; }
 
   /** Returns the intitial Version associated with this Version. */
   get initial(): Version { return new Version(this.base); }
 
+  /** Returns true if the Version is an intitial sub version. */
+  get isInitial(): boolean { return this.sub == 0; }
+
   /** Returns the next sub version associated with this Version. */
   get next(): Version { return new Version(this.base, Version._randomId()); }
 
-  /** Returns the base version. */
-  get base(): string { return this._value.base; }
+  /** Returns the serialization of the Version. A Version is only serialized at instantiation. */
+  get serial(): string { return this._serial; }
 
   /** Returns the sub version. */
   get sub(): number { return this._value.sub; }
@@ -143,55 +185,40 @@ export class Version {
   /** Returns the base and sub version. */
   get value(): PlainVersion { return this._value; }
 
-  /** Returns the serialization of the Version. A Version is only serialized at instantiation. */
-  get serial(): string { return this._serial; }
-}
-
-/**
- * A Record is a version of an object persisted in cache and identified by a single
- * combination of a key and a Version. The key identifies the Chain of Records for a single object
- * and the Version identifies the particular Record of that object.
- *
- * Each instance of a Record requires the object 'value' and the Version that identifies it.
- */
-export class Record {
-  constructor(public value: Object, public version: Version) {}
+  /** Returns true if this Version has a matching 'base' and 'sub' to 'other'. */
+  isEqual(other: Version): boolean { return this.base == other.base && this.sub == other.sub; }
 }
 
 // Error types intended to be emitted by Store instances.
 //==================================================================================================
 
 /**
- * The range of errors that can be emitted by a Store instance.
+ * Thrown when a method uses a provided key that has no matching Chain in the Store.
  */
-export enum StoreErrorType {
-  DeprecatedMutation,
-  InvalidTargetVersion
-}
-;
-
-/**
- * The parent type of all errors emitted by a Store instance. The type will denote the
- * implementation of the error emitted.
- */
-export interface StoreError { type: StoreErrorType; }
-
-/**
- * The implementation of the DeprecatedMutation error type.
- */
-export interface ErrorDM extends StoreError {
-  initial: Record;   // Record of the deprecated initial version
-  mutation: Record;  // Record of the mutation on the deprecated version
-  current: Record;   // Record which is considered current by the store
+export class KeyNotFoundError {
+  /** Contains the non-matching 'key'. */
+  constructor(public key: Object) {}
 }
 
 /**
- * The implementation of the InvalidTargetVersion error type.
+ * Throw when an 'abandon' targets an initial Version.
  */
-export interface ErrorITV extends StoreError {
-  target: Version;   // the Version to be mutated
-  mutation: Object;  // mutation to be applied to target Version
-  current: Record;   // Record which is considered current by the store
+export class InvalidInitialTargetVersionError {
+  /** Contains the 'key' and the invalid initial 'target' Version. */
+  constructor(public key: Object, public target: Version) {}
+}
+/**
+ * Thrown when a 'commit' targets a Version that does not match the most current Record.
+ */
+export class OutdatedTargetVersionError {
+  /**
+   * Contains the 'key' for the 'mutation', the Version that is 'current' in the Store, the Version
+   * that
+   * was the 'target' of the 'mutation', the 'mutation' that was to be applied, and the 'context'
+   * information associated with the 'mutation'.
+   */
+  constructor(public key: Object, public current: Version, public target: Version,
+              public mutation: Object, public context: Object) {}
 }
 
 // Store implementations.
@@ -201,56 +228,61 @@ export interface ErrorITV extends StoreError {
  * A storage backend.
  */
 export interface Store {
+  /** A stream of outdated mutations emitted by the Store. */
+  outdated: Observable<OutdatedMutation>;
+
+  /** A stream of pending mutations emitted by the Store. */
+  pending: Observable<PendingMutation>;
+
   /**
-   * Reads a Record from the store.
+   * Removes the 'target' Version from the Store.
+   *
+   * If the 'target' Version is an initial Version, then 'abandon' will throw an
+   * InvalidInitialTargetVersionError.
+   *
+   * If the 'target' Version does not match the Version that is current in the Store, then the
+   * 'target' Version and any Records associated with it will be removed from the Store.
+   *
+   * If the 'key' does not match any Record in the Store, 'abandon' will throw a KeyNotFoundError.
+   *
+   * 'abandon' will complete when the affected Records are removed from the Store.
+   */
+  abandon(key: Object, target: Version): Observable<void>;
+
+  /**
+   * Stores a pending mutation into the Store as the most recent version. The pending mutation will
+   * be emitted on the 'pending' stream.
+   *
+   * If there is a previous pending mutation attached to the current Version, it will be
+   * replaced with 'mutation'.
+   *
+   * If the 'key' does not match any Record in the Store, 'commit' will throw a KeyNotFoundError.
+   *
+   * If the 'target' Version for the 'mutation' is no longer current, 'commit' will throw
+   * an OutdatedTargetVersionError.
+   */
+  commit(key: Object, target: Version, mutation: Object, context: Object): Observable<void>;
+
+  /**
+   * Reads a Record from the Store.
    *
    * If a Version is supplied, 'fetch' will emit the Record associated with that Version. Otherwise
-   * 'fetch' will emit the most recently committed or pushed Record matching 'key'.
+   * 'fetch' will emit the most recently 'commit'ted or 'push'ed Record matching 'key'.
    *
-   * If the 'key' or 'version' does not match any Record in the store, then 'fetch' will emit null.
+   * If the 'key' or 'version' does not match any Record in the Store, then 'fetch' will emit null.
    */
   fetch(key: Object, version?: Version): Observable<Record>;
 
   /**
-   * Stores a Record into the store as the most recent version.
+   * Stores a Record into the Store as the most recent version.
    *
-   * If the current version has a pending mutation, 'push' will complete and throw a pending
-   * mutation error (ErrorDM). Otherwise, 'push' will emit whether or not it was successful. If the
-   * current version does not have a pending mutation, it will removed from the store.
+   * If the current Record is not a pending mutation or if the current Record matches 'resolves',
+   * it will be removed from the Store.
+   *
+   * If the current Record is a pending mutation, 'push' will emit an OutdatedMutation on the
+   * 'outdated' stream.
    */
-  push(key: Object, value: Object, base: string): Observable<boolean>;
-
-  /**
-   * Stores a pending mutation into the store as the most recent version.
-   *
-   * If the target version for the mutation is no longer current, 'commit' will complete and throw
-   * an invalid target version error (ErrorITV). Otherwise, 'commit' will emit the Record for the
-   * pending mutation.
-   *
-   * If the 'key' or 'version' does not match any Record in the store, 'commit' will emit null.
-   */
-  commit(key: Object, mutation: Object, target: Version): Observable<Record>;
-
-  /**
-   * Removes the pending mutation that matches 'key' and 'base'.
-   *
-   * If 'base' does not match the most recent Record, then all Records matching 'base' will be
-   * removed from the store.
-   *
-   * If 'key' or 'base' does not match any Record in the store, then 'rollback' will emit
-   * false. Otherwise, 'rollback' will emit whether or not it was successful.
-   */
-  rollback(key: Object, base: string): Observable<boolean>;
-
-  /**
-   * Checks if there are pending mutations in the Store and emits the Records for those mutations
-   * if there are.
-   *
-   * If there is a deprecated mutation contained in the store, then 'pending' throw a deprecated
-   * mutation error (ErrorDM). If there is pending mutation, then 'current' will be the pending
-   * mutation. Otherwise, 'current' will be an initial version.
-   */
-  pending(): Observable<Record>;
+  push(key: Object, base: string, value: Object, resolves?: Version): Observable<void>;
 }
 
 /**
@@ -263,340 +295,187 @@ export class TacticalStore implements Store {
   private static _records: string = "records";
 
   private _idb: Idb;
+  private _outdated: Subject<OutdatedMutation> = new Subject<OutdatedMutation>();
+  private _pending: Subject<PendingMutation> = new Subject<PendingMutation>();
 
+  /**
+   * Takes a factory function used to generate an Idb implementation and a name
+   * to use, if any, for the target database.
+   */
   constructor(idbFactory: IdbFactory, appDB?: string) {
     this._idb = idbFactory((appDB) ? appDB : 'tactical_db',
                            [TacticalStore._chains, TacticalStore._records]);
   }
 
-  /**
-   * Reads a Record from the store.
-   *
-   * If a Version is supplied, 'fetch' will emit the Record associated with that Version. Otherwise
-   * 'fetch' will emit the most recently committed or pushed Record matching 'key'.
-   *
-   * If the 'key' or 'version' does not match any Record in the store, then 'fetch' will emit null.
-   */
+  get outdated(): Observable<OutdatedMutation> { return this._outdated; }
+
+  get pending(): Observable<PendingMutation> { return this._pending; }
+
+  abandon(key: Object, target: Version): Observable<void> {
+    var targetKey: RecordKey = new RecordKey(new ChainKey(key), target);
+    return this._idb.transaction([TacticalStore._chains, TacticalStore._records])
+        .flatMap((txn: IdbTransaction) => {
+          return txn.get(TacticalStore._chains, targetKey.chain.serial)
+              .flatMap((state: ChainState) => {
+                if (!state) {
+                  throw new KeyNotFoundError(key);
+                }
+                if (!state.current) {
+                  return Observable.empty<void>();
+                }
+                if (target.isInitial) {
+                  throw new InvalidInitialTargetVersionError(key, target);
+                }
+                var current: Version = Version.from(state.current);
+                var res = Observable.just<boolean>(true);
+                if (target.isEqual(current)) {
+                  state.current = current.initial.value;
+                  res = txn.remove(TacticalStore._records, targetKey.serial);
+                } else {
+                  for (var i = 0; i < state.outdated.length; i++) {
+                    if (target.isEqual(Version.from(state.outdated[i]))) {
+                      state.outdated.splice(i, 1);
+                      break;
+                    }
+                  }
+                  res = this._removeBase(targetKey, txn);
+                }
+                return res.flatMap(
+                              () => txn.put(TacticalStore._chains, targetKey.chain.serial, state))
+                    .flatMap(() => Observable.empty<void>());
+              });
+        });
+  }
+
+  commit(key: Object, target: Version, mutation: Object, context: Object): Observable<void> {
+    var targetKey: RecordKey = new RecordKey(new ChainKey(key), target);
+    return this._idb.transaction([TacticalStore._chains, TacticalStore._records])
+        .flatMap((txn: IdbTransaction) => {
+          return txn.get(TacticalStore._chains, targetKey.chain.serial)
+              .flatMap((state: ChainState) => {
+                if (!state || !state.current) {
+                  throw new KeyNotFoundError(key);
+                }
+                var previousVersion: Version = Version.from(state.current);
+                if (!target.isEqual(previousVersion)) {
+                  throw new OutdatedTargetVersionError(key, previousVersion, target, mutation,
+                                                       context);
+                }
+                var mutationKey: RecordKey = new RecordKey(targetKey.chain, previousVersion.next);
+                state.current = mutationKey.version.value;
+                var res = txn.put(TacticalStore._chains, mutationKey.chain.serial, state)
+                              .flatMap(() => txn.put(TacticalStore._records, mutationKey.serial,
+                                                     {value: mutation, context: context}));
+                if (!previousVersion.isInitial) {
+                  res = res.flatMap(() => txn.remove(TacticalStore._records, targetKey.serial));
+                }
+                return res.flatMap(() => {
+                  this._pending.onNext(
+                      new PendingMutation(key, new Record(mutationKey.version, mutation, context)));
+                  return Observable.empty<void>();
+                });
+              });
+        });
+  }
+
   fetch(key: Object, version?: Version): Observable<Record> {
     var chainKey: ChainKey = new ChainKey(key);
     if (version) {
       return this._fetchRecord(new RecordKey(chainKey, version));
     }
-    return this._idb.get(TacticalStore._chains, chainKey.serial)
-        .flatMap((state: ChainState) => {
-          if (!state || !state.current) {
-            return Observable.just<Record>(null);
-          }
-          return this._fetchRecord(new RecordKey(chainKey, Version.from(state.current)))
-              .flatMap((record: Record) => {
-                if (record) {
-                  return Observable.just<Record>(record);
+    return this._idb.transaction([TacticalStore._chains, TacticalStore._records])
+        .flatMap((txn: IdbTransaction) => {
+          return txn.get(TacticalStore._chains, chainKey.serial)
+              .flatMap((state: ChainState) => {
+                if (!state || !state.current) {
+                  return Observable.just<Record>(null);
                 }
-                if (!state.backup) {
-                  return Observable.just<Record>(null);  // state is corrupted
-                }
-                // the chain state might be corrupted, check if a backup Record exists
-                return this._fetchRecord(new RecordKey(chainKey, Version.from(state.backup)));
+                return this._fetchRecord(new RecordKey(chainKey, Version.from(state.current)), txn);
               });
         });
   }
 
-  /**
-   * Stores a Record into the store as the most recent version.
-   *
-   * If the current version has a pending mutation, 'push' will complete and throw a pending
-   * mutation error (ErrorDM). Otherwise, 'push' will emit whether or not it was successful. If the
-   * current version does not have a pending mutation, it will removed from the store.
-   */
-  push(key: Object, value: Object, base: string): Observable<boolean> {
+  push(key: Object, base: string, value: Object, resolves?: Version): Observable<void> {
     var pushKey: RecordKey = new RecordKey(new ChainKey(key), new Version(base));
     return this._idb.transaction([TacticalStore._chains, TacticalStore._records])
-        .flatMap((transaction: IdbTransaction) => {
-          return transaction.get(TacticalStore._chains, pushKey.chain.serial)
+        .flatMap((txn: IdbTransaction) => {
+          return txn.get(TacticalStore._chains, pushKey.chain.serial)
               .flatMap((state: ChainState) => {
-
+                var previousVersion: Version;
                 if (!state) {
-                  state = {current: null, backup: null, deprecated: null};  // first 'push'
+                  state = {current: null, outdated: []};  // first 'push'
+                } else {
+                  previousVersion = Version.from(state.current);
                 }
-
-                state.current = pushKey.version.value;  // mark that a Record is being stored
-
-                return transaction.put(TacticalStore._chains, pushKey.chain.serial, state)
-                    .flatMap((ok: boolean) => {
-                      if (!ok) {
-                        return Observable.just<boolean>(false);  // Idb complication
-                      }
-                      return transaction.put(TacticalStore._records, pushKey.serial, value);
-                    })
-                    .flatMap((ok: boolean) => {
-                      if (!ok) {
-                        return Observable.just<boolean>(false);  // state is dirty
-                      }
-                      if (!state.backup) {
-                        return Observable.just<boolean>(true);  // first 'push'
-                      }
-
-                      var backup: Version = Version.from(state.backup);
-
-                      // check if there is a pending mutation
-                      if (!backup.isInitial) {
-                        var current: Record = new Record(value, pushKey.version);
-                        if (!state.deprecated) {
-                          state.deprecated = backup.value;  // deprecate mutation
-                          return this._throwErrorDM(pushKey.chain, backup, current);
+                state.current = pushKey.version.value;
+                var isOutdated: boolean = previousVersion && !previousVersion.isInitial;
+                var isResolved: boolean = resolves && previousVersion.isEqual(resolves);
+                if (isOutdated && !isResolved) {
+                  state.outdated.push(previousVersion.value);
+                }
+                return txn.put(TacticalStore._chains, pushKey.chain.serial, state)
+                    .flatMap(() => txn.put(TacticalStore._records, pushKey.serial,
+                                           {value: value, context: {}}))
+                    .flatMap(() => {
+                      var res = Observable.just<boolean>(true);
+                      if (previousVersion) {
+                        if (previousVersion.isInitial || isResolved) {
+                          res =
+                              this._removeBase(new RecordKey(pushKey.chain, previousVersion), txn);
+                        } else if (!isResolved) {
+                          res = this._emitOutdatedMutation(
+                              new RecordKey(pushKey.chain, previousVersion),
+                              new Record(pushKey.version, value), txn)
                         }
-                        // deprecations follow highlander rules; there can be only one!
-                        return this._remove(transaction, pushKey.chain, state.deprecated)
-                            .flatMap((ok: boolean) => {
-                              if (!ok) {
-                                return Observable.just<boolean>(false);  // state is dirty
-                              }
-                              state.deprecated = backup.value;  // deprecate mutation
-                              return this._throwErrorDM(pushKey.chain, backup, current);
-                            });
                       }
-
-                      // remove the previous Record if there is no pending mutation
-                      return this._remove(transaction, pushKey.chain, backup.value);
-                    })
-                    .flatMap((ok: boolean) => {
-                      if (!ok) {
-                        return Observable.just<boolean>(false);  // state is dirty
-                      }
-                      state.backup = pushKey.version.value;  // finalize Record
-                      return transaction.put(TacticalStore._chains, pushKey.chain.serial, state);
+                      return res.flatMap(() => Observable.empty<void>());
                     });
-              });
-        })
-        .take(1);
-  }
-
-  /**
-   * Stores a pending mutation into the store as the most recent version.
-   *
-   * If the target version for the mutation is no longer current, 'commit' will complete and throw
-   * an invalid target version error (ErrorITV). Otherwise, 'commit' will emit the Record for the
-   * pending mutation.
-   *
-   * If the 'key' or 'version' does not match any Record in the store, 'commit' will emit null.
-   */
-  commit(key: Object, mutation: Object, target: Version): Observable<Record> {
-    var targetKey: RecordKey = new RecordKey(new ChainKey(key), target);
-    return this._idb.transaction([TacticalStore._chains, TacticalStore._records])
-        .flatMap((transaction: IdbTransaction) => {
-          return transaction.get(TacticalStore._chains, targetKey.chain.serial)
-              .flatMap((state: ChainState) => {
-
-                if (!state || !state.current) {
-                  return Observable.just<Record>(null);
-                }
-
-                // mutation should target the current version
-                if (!target.isEqual(state.current.base, state.current.sub)) {
-                  return this._throwErrorITV(key, mutation, target);
-                }
-
-                var mutRcd: Record = new Record(mutation, target.next);
-                var mutKey: RecordKey = new RecordKey(targetKey.chain, mutRcd.version);
-                state.current = mutRcd.version.value;  // mark that a Record is being stored
-
-                return transaction.put(TacticalStore._chains, targetKey.chain.serial, state)
-                    .flatMap((ok: boolean) => {
-                      if (!ok) {
-                        return Observable.just<boolean>(false);  // Idb complication
-                      }
-                      return transaction.put(TacticalStore._records, mutKey.serial, mutation);
-                    })
-                    .flatMap((ok: boolean) => {
-                      if (!ok) {
-                        return Observable.just<boolean>(false);  // state is dirty
-                      }
-                      if (target.isInitial) {
-                        return Observable.just<boolean>(true);  // don't remove intial versions
-                      }
-                      // mutations follow highlander rules; there can be only one!
-                      return transaction.remove(TacticalStore._records, targetKey.serial);
-                    })
-                    .flatMap((ok: boolean) => {
-                      if (!ok) {
-                        return Observable.just<boolean>(false);  // state is dirty
-                      }
-                      state.backup = mutRcd.version.value;  // finalize Record
-                      return this._idb.put(TacticalStore._chains, targetKey.chain.serial, state);
-                    })
-                    .map((ok: boolean) => (ok) ? mutRcd : null);
-              });
-        })
-        .take(1);
-  }
-
-  /**
-   * Removes the pending mutation that matches 'key' and 'base'.
-   *
-   * If 'base' does not match the most recent Record, then all Records matching 'base' will be
-   * removed from the store.
-   *
-   * If 'key' or 'base' does not match any Record in the store, then 'rollback' will emit
-   * false. Otherwise, 'rollback' will emit whether or not it was successful.
-   */
-  rollback(key: Object, base: string): Observable<boolean> {
-    var chainKey: ChainKey = new ChainKey(key);
-    var target: Version = new Version(base);
-    return this._idb.transaction([TacticalStore._chains, TacticalStore._records])
-        .flatMap((transaction: IdbTransaction) => {
-          return transaction.get(TacticalStore._chains, chainKey.serial)
-              .flatMap((state: ChainState) => {
-
-                if (!state || !state.current) {
-                  return Observable.just<boolean>(false);
-                }
-
-                // check if 'rollback' was called on the 'deprecated' version
-                if (!target.isEqual(state.current.base)) {
-                  if (!state.deprecated || !target.isEqual(state.deprecated.base)) {
-                    return Observable.just<boolean>(false);  // invalid target
-                  }
-                  // calling 'rollback' on a 'deprecated' base is equivalent to removing it
-                  return this._remove(transaction, chainKey, state.deprecated)
-                      .flatMap((ok: boolean) => {
-                        if (!ok) {
-                          return Observable.just<boolean>(false);  // state is dirty
-                        }
-                        state.deprecated = null;
-                        return this._idb.put(TacticalStore._chains, chainKey.serial, state);
-                      });
-                }
-
-                if (Version.from(state.current).isInitial) {
-                  return Observable.just<boolean>(true);
-                }
-
-                state.current = target.value;  // mark that a Record is being stored
-
-                return transaction.put(TacticalStore._chains, chainKey.serial, state)
-                    .flatMap((ok: boolean) => {
-                      if (!ok) {
-                        return Observable.just<boolean>(false);  // Idb complication
-                      }
-                      // remove the pending mutation
-                      var mutKey: RecordKey = new RecordKey(chainKey, Version.from(state.backup));
-                      return transaction.remove(TacticalStore._records, mutKey.serial)
-                          .flatMap((ok: boolean) => {
-                            if (!ok) {
-                              return Observable.just<boolean>(false);  // state is dirty
-                            }
-                            state.backup = target.value;  // finalize Record
-                            return transaction.put(TacticalStore._chains, chainKey.serial, state);
-                          });
-                    });
-              });
-        })
-        .take(1);
-  }
-
-  /**
-   * Checks if there are pending mutations in the Store and emits the Records for those mutations
-   * if there are.
-   *
-   * If there is a deprecated mutation contained in the store, then 'pending' throw a deprecated
-   * mutation error (ErrorDM). If there is pending mutation, then 'current' will be the pending
-   * mutation. Otherwise, 'current' will be an initial version.
-   */
-  pending(): Observable<Record> {
-    return this._idb.keys(TacticalStore._chains)
-        .flatMap((key: string) => {
-          var chainKey: ChainKey = new ChainKey(key);
-
-          return this._idb.get(TacticalStore._chains, chainKey.serial)
-              .take(1)
-              .flatMap((state: ChainState) => {
-
-                if (!state || !state.current) {
-                  return Observable.just<Record>(null);
-                }
-
-                var current: Version = Version.from(state.current);
-
-                // check if there is a deprecated mutation
-                if (state.deprecated) {
-                  return this._fetchRecord(new RecordKey(chainKey, current))
-                      .flatMap((currentRcd: Record) => {
-                        var deprecated: Version = Version.from(state.deprecated);
-                        return this._throwErrorDM(chainKey, deprecated, currentRcd);
-                      });
-                }
-
-                // check if there is a pending mutation
-                if (!current.isInitial) {
-                  return this._fetchRecord(new RecordKey(chainKey, current));
-                }
-
-                return Observable.empty<Record>();
               });
         });
   }
 
   /**
-   * Reads a Record from the store.
+   * Emits an outdated mutation on the 'outdated' stream.
+   */
+  private _emitOutdatedMutation(mutationKey: RecordKey, current: Record,
+                                txn: IdbTransaction): Observable<boolean> {
+    return this._fetchRecord(mutationKey, txn)
+        .flatMap((mutation: Record) => {
+          return this._fetchRecord(new RecordKey(mutationKey.chain, mutationKey.version.initial),
+                                   txn)
+              .map((initial: Record) =>
+                       new OutdatedMutation(mutationKey.chain.key, current, mutation, initial));
+        })
+        .map((outdatedMutation: OutdatedMutation) => {
+          this._outdated.onNext(outdatedMutation);
+          return true;
+        });
+  }
+
+  /**
+   * Reads a Record from the Store.
    *
-   * If the 'key' does not match any Record in the store, then '_fetchRecord' will emit null.
+   * If the 'key' does not match any Record in the Store, then '_fetchRecord' will emit null.
    */
-  private _fetchRecord(key: RecordKey): Observable<Record> {
-    return this._idb.get(TacticalStore._records, key.serial)
-        .map((value: Object) => { return (value) ? new Record(value, key.version) : null; })
-        .take(1);
+  private _fetchRecord(key: RecordKey, txn?: IdbTransaction): Observable<Record> {
+    return ((txn) ? Observable.just<IdbTransaction>(txn) :
+                    this._idb.transaction([TacticalStore._records]))
+        .flatMap((txn: IdbTransaction) => txn.get(TacticalStore._records, key.serial))
+        .map((entry: Entry) =>
+                 (entry) ? new Record(key.version, entry.value, entry.context) : null);
   }
 
   /**
-   * Returns an Observable that will emit a deprecated mutation error.
+   * Removes the Record of the mutation and the Record of the initial specified by the
+   * provided 'targetKey'.
    */
-  private _throwErrorDM(key: ChainKey, mutation: Version, current: Record): Observable<any> {
-    var initRcd: Observable<Record> = this._fetchRecord(new RecordKey(key, mutation.initial));
-    var mutRcd: Observable<Record> = this._fetchRecord(new RecordKey(key, mutation));
-    return initRcd.forkJoin(mutRcd, (left: Record, right: Record) => {
-                    var error: ErrorDM = {
-                      type: StoreErrorType.DeprecatedMutation,
-                      initial: left,
-                      mutation: right,
-                      current: current
-                    };
-                    return error;
-                  }).flatMap((error: ErrorDM) => { return Observable.throw<any>(error); });
-  }
-
-  /**
-   * Returns an Observable that will emit a invalid target version error.
-   */
-  private _throwErrorITV(key: Object, mutation: Object, target: Version): Observable<any> {
-    return this.fetch(key).flatMap((record: Record) => {
-      var error: ErrorITV = {
-        type: StoreErrorType.InvalidTargetVersion,
-        target: target,
-        mutation: mutation,
-        current: record
-      };
-      return Observable.throw<any>(error);
-    });
-  }
-
-  /**
-   * Removes the Records from the store matching 'key' and 'version', including the initial
-   * version.
-   *
-   * If the provided 'key' or 'version' are non-matching, '_remove' will emit true. Otherwise,
-   * '_remove' will emit whether or not it was successful.
-   */
-  private _remove(transaction: IdbTransaction, key: ChainKey,
-                  version: PlainVersion): Observable<boolean> {
-    var mutKey: RecordKey = new RecordKey(key, Version.from(version));
-    if (mutKey.version.isInitial) {
-      return transaction.remove(TacticalStore._records, mutKey.serial).take(1);
+  private _removeBase(targetKey: RecordKey, txn: IdbTransaction): Observable<boolean> {
+    var res = txn.remove(TacticalStore._records, targetKey.serial);
+    if (!targetKey.version.isInitial) {
+      var initKey: RecordKey = new RecordKey(targetKey.chain, targetKey.version.initial);
+      res = res.flatMap(() => txn.remove(TacticalStore._records, initKey.serial));
     }
-    var initKey: RecordKey = new RecordKey(key, mutKey.version.initial);
-    return transaction.remove(TacticalStore._records, mutKey.serial)
-        .take(1)
-        .forkJoin(transaction.remove(TacticalStore._records, initKey.serial).take(1),
-                  (left: boolean, right: boolean) => { return left && right; });
+    return res;
   }
 }
 
@@ -604,21 +483,27 @@ export class TacticalStore implements Store {
  * An implementation of a Store that does nothing.
  */
 export class NoopStore implements Store {
+  get outdated(): Observable<OutdatedMutation> {
+    return Observable.empty<OutdatedMutation>(Scheduler.default);
+  }
+
+  get pending(): Observable<PendingMutation> {
+    return Observable.empty<PendingMutation>(Scheduler.default);
+  }
+
+  abandon(key: Object, target: Version): Observable<void> {
+    return Observable.empty<void>(Scheduler.default);
+  }
+
+  commit(key: Object, mutation: Object, context: Object, target: Version): Observable<void> {
+    return Observable.empty<void>(Scheduler.default);
+  }
+
   fetch(key: Object, version?: Version): Observable<Record> {
-    return Observable.just<Record>(null, Scheduler.currentThread);
+    return Observable.just<Record>(null, Scheduler.default);
   }
 
-  push(key: Object, value: Object, base: string): Observable<boolean> {
-    return Observable.just<boolean>(true, Scheduler.currentThread);
+  push(key: Object, base: string, value: Object, resolves?: Version): Observable<void> {
+    return Observable.empty<void>(Scheduler.default);
   }
-
-  commit(key: Object, mutation: Object, target: Version): Observable<Record> {
-    return Observable.just<Record>(null, Scheduler.currentThread);
-  }
-
-  rollback(key: Object, base: string): Observable<boolean> {
-    return Observable.just<boolean>(true, Scheduler.currentThread);
-  }
-
-  pending(): Observable<Record> { return Observable.empty<Record>(Scheduler.currentThread); }
 }

--- a/modules/tactical/test/data_manager_spec.ts
+++ b/modules/tactical/test/data_manager_spec.ts
@@ -51,8 +51,9 @@ describe('DataManager', () => {
     var be = new FakeBackend();
     var ts = new TacticalStore(InMemoryIdbFactory);
     var dm = new TacticalDataManager(be, ts);
-    ts.push({key: true}, {foo: 'goodbye'}, 'v1')
-        .flatMap((ok: boolean) => { return dm.request({key: true}); })
+    ts.push({key: true}, 'v1', {foo: 'goodbye'})
+        .defaultIfEmpty()
+        .flatMap(() => dm.request({key: true}))
         .subscribe((data: Object) => {
           expect(data['foo']).to.equal('goodbye');
           done();
@@ -64,8 +65,9 @@ describe('DataManager', () => {
     var dm = new TacticalDataManager(be, ts);
     be.load(_versioned('v1', {key: true}, {foo: 'goodbye'}), false);
     var first = true;
-    ts.push({key: true}, {foo: 'hello'}, 'v1')
-        .flatMap((ok: boolean) => { return dm.request({key: true}); })
+    ts.push({key: true}, 'v1', {foo: 'hello'})
+        .defaultIfEmpty()
+        .flatMap(() => dm.request({key: true}))
         .subscribe((data: Object) => {
           if (first) {
             expect(data['foo']).to.equal('hello');

--- a/modules/tactical/test/tactical_store_spec.ts
+++ b/modules/tactical/test/tactical_store_spec.ts
@@ -4,334 +4,299 @@
 import {expect} from 'chai';
 import {InMemoryIdbFactory} from '../src/idb';
 import {
+  KeyNotFoundError,
+  InvalidInitialTargetVersionError,
+  OutdatedMutation,
+  OutdatedTargetVersionError,
+  PendingMutation,
   Record,
-  ErrorDM,
-  ErrorITV,
-  StoreError,
-  StoreErrorType,
   TacticalStore,
   Version
 } from '../src/tactical_store';
 
+import {Scheduler} from 'rx';
+
 describe("Tactical Store", () => {
 
   var key: Object = {key: 'key'};
-  var notkey: Object = {key: 'notkey'};
+  var notKey: Object = {key: 'notkey'};
 
-  var foobase: string = 'foobase';
-  var barbase: string = 'barbase';
-  var notbase: string = 'notbase';
+  var fooVer: Version = new Version('foobase');
+  var barVer: Version = new Version('barbase');
+  var notVer: Version = new Version('notbase');
 
   var foo: Object = {value: 'foo'};
   var foobaz: Object = {value: 'foobaz'};
   var bar: Object = {value: 'bar'};
 
-  it("should fetch the most recently committed or pushed Record", (done) => {
-    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.fetch(key);
-        })
-        .flatMap((record: Record) => {
-          expect(record.version.base).to.equal(foobase);
-          expect(record.value['value']).to.equal('foo');
-          return ts.commit(key, foobaz, new Version(foobase));
-        })
-        .flatMap((record: Record) => {
-          expect(record).to.not.be.null;
-          return ts.fetch(key);
-        })
-        .subscribeOnNext((record: Record) => {
-          expect(record.value['value']).to.equal('foobaz');
-          done();
-        });
-  });
-  it("should fetch a specific Record", (done) => {
-    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.fetch(key, new Version(foobase));
-        })
-        .subscribeOnNext((record: Record) => {
-          expect(record.version.base).to.equal(foobase);
-          expect(record.value['value']).to.equal('foo');
-          done();
-        });
-  });
-  it("should fetch null for a non-matching key or version", (done) => {
-    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.fetch(notkey, new Version(foobase));
-        })
-        .flatMap((record: Record) => {
-          expect(record).to.be.null;
-          return ts.fetch(key, new Version(notbase));
-        })
-        .subscribeOnNext((record: Record) => {
-          expect(record).to.be.null;
-          done();
-        });
-  });
+  var emptyCntxt: Object = {};
+  var fooCntxt: Object = {time: 'footime'};
+  var barCntxt: Object = {time: 'bartime'};
 
-  it("should store a Record into the store as the most recent version", (done) => {
+  it("fetch should emit the most recently committed or pushed Record", (done) => {
     var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.push(key, bar, barbase);
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.fetch(key))
+        .flatMap((record: Record) => {
+          expect(record.version.isEqual(fooVer)).to.be.true;
+          expect(record.value).to.deep.equal(foo);
+          expect(record.context).to.deep.equal(emptyCntxt);
+          return ts.commit(key, fooVer, foobaz, fooCntxt);
         })
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.fetch(key);
-        })
+        .defaultIfEmpty()
+        .flatMap(() => ts.fetch(key))
         .subscribeOnNext((record: Record) => {
-          expect(record.version.base).to.equal(barbase);
-          expect(record.value['value']).to.equal('bar');
+          expect(record.version.base).to.equal(fooVer.base);
+          expect(record.value).to.deep.equal(foobaz);
+          expect(record.context).to.deep.equal(fooCntxt);
           done();
         });
   });
-  it("should remove the previous Record, if there is no pending mutation", (done) => {
+  it("fetch should emit a specific Record", (done) => {
     var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.push(key, bar, barbase);
-        })
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.fetch(key, new Version(foobase));
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.fetch(key, fooVer))
+        .subscribeOnNext((record: Record) => {
+          expect(record.version.isEqual(fooVer)).to.be.true;
+          expect(record.value).to.deep.equal(foo);
+          expect(record.context).to.deep.equal(emptyCntxt);
+          done();
+        });
+  });
+  it("fetch should emit null for a non-matching key or version", (done) => {
+    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.fetch(notKey, fooVer))
+        .flatMap((record: Record) => {
+          expect(record).to.be.null;
+          return ts.fetch(key, notVer);
         })
         .subscribeOnNext((record: Record) => {
           expect(record).to.be.null;
           done();
         });
   });
-  it("should throw a deprecated mutation error", (done) => {
+  it("push should store a Record as the most recent version", (done) => {
     var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.commit(key, foobaz, new Version(foobase));
-        })
-        .flatMap((record: Record) => {
-          expect(record).to.not.be.null;
-          return ts.push(key, bar, barbase);
-        })
-        .subscribeOnError((error: ErrorDM) => {
-          expect(error.type).to.equal(StoreErrorType.DeprecatedMutation);
-          expect(error.initial.value['value']).to.equal('foo');
-          expect(error.mutation.value['value']).to.equal('foobaz');
-          expect(error.current.value['value']).to.equal('bar');
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.push(key, barVer.base, bar))
+        .defaultIfEmpty()
+        .flatMap(() => ts.fetch(key))
+        .subscribeOnNext((record: Record) => {
+          expect(record.version.isEqual(barVer)).to.be.true;
+          expect(record.value).to.deep.equal(bar);
+          expect(record.context).to.deep.equal(emptyCntxt);
           done();
         });
   });
-  it("should remove the previous deprecated mutation", (done) => {
+  it("push should remove the previous Record, if it is not a pending mutation", (done) => {
     var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.commit(key, foobaz, new Version(foobase));
-        })
-        .flatMap((record: Record) => {
-          expect(record).to.not.be.null;
-          return ts.push(key, bar, barbase);
-        })
-        .subscribeOnError((error: StoreError) => {
-          return ts.commit(key, foobaz, new Version(barbase))
-              .flatMap((record: Record) => {
-                expect(record).to.not.be.null;
-                return ts.push(key, foo, notbase);
-              })
-              .subscribeOnError((otherError: StoreError) => {
-                return ts.fetch(key, new Version(foobase))
-                    .flatMap((record: Record) => {
-                      expect(record).to.be.null;
-                      var mutationVersion: Version = new Version(foobase).next;
-                      return ts.fetch(key, mutationVersion);
-                    })
-                    .subscribeOnNext((record: Record) => {
-                      expect(record).to.be.null;
-                      done();
-                    });
-              });
-        });
-  });
-
-  it("should store a pending mutation into the store", (done) => {
-    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.commit(key, foobaz, new Version(foobase));
-        })
-        .subscribe((record: Record) => {
-          expect(record.value['value']).to.equal('foobaz');
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.push(key, barVer.base, bar))
+        .defaultIfEmpty()
+        .flatMap(() => ts.fetch(key, fooVer))
+        .subscribeOnNext((record: Record) => {
+          expect(record).to.be.null;
           done();
         });
   });
-  it("should throw an invalid target version error", (done) => {
+  it("push should remove the previous Record, if it has been resolved", (done) => {
     var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.commit(key, bar, new Version(barbase));
-        })
-        .subscribeOnError((error: ErrorITV) => {
-          expect(error.type).to.equal(StoreErrorType.InvalidTargetVersion);
-          expect(error.target.base).to.equal('barbase');
-          expect(error.mutation['value']).to.equal('bar');
-          expect(error.current.value['value']).to.equal('foo');
-          done();
-        });
-  });
-  it("should remove the previous mutation, if one exists", (done) => {
-    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.commit(key, foobaz, new Version(foobase));
-        })
-        .flatMap((foobazRecord: Record) => {
-          expect(foobazRecord).to.not.be.null;
-          return ts.commit(key, bar, foobazRecord.version)
-              .map((barRecord: Record) => { return foobazRecord; });
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.commit(key, fooVer, foobaz, fooCntxt))
+        .subscribeOn(Scheduler.default)
+        .subscribe();
+    ts.pending.take(1)
+        .flatMap((pending: PendingMutation) => {
+          return ts.push(key, barVer.base, bar, pending.mutation.version)
+              .defaultIfEmpty()
+              .flatMap(() => ts.fetch(key, pending.mutation.version));
         })
         .flatMap((record: Record) => {
-          expect(record).to.not.be.null;
-          return ts.fetch(key, record.version);
+          expect(record).to.be.null;
+          return ts.fetch(key, fooVer);
         })
         .subscribeOnNext((record: Record) => {
           expect(record).to.be.null;
           done();
         });
   });
-  it("should emit null and not emit any errors for a non-matching key", (done) => {
+  it("push should emit an outdated mutation on the outdated stream", (done) => {
     var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.commit(notkey, foobaz, new Version(foobase));
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.commit(key, fooVer, foobaz, fooCntxt))
+        .defaultIfEmpty()
+        .flatMap(() => ts.push(key, barVer.base, bar))
+        .subscribeOn(Scheduler.default)
+        .subscribe();
+    ts.outdated.subscribeOnNext((outdated: OutdatedMutation) => {
+      expect(outdated.key).to.deep.equal(key);
+      expect(outdated.initial.version.isEqual(fooVer)).to.be.true;
+      expect(outdated.initial.value).to.deep.equal(foo);
+      expect(outdated.initial.context).to.deep.equal(emptyCntxt);
+      expect(outdated.mutation.version.base).to.equal(fooVer.base);
+      expect(outdated.mutation.value).to.deep.equal(foobaz);
+      expect(outdated.mutation.context).to.deep.equal(fooCntxt);
+      expect(outdated.current.version.isEqual(barVer)).to.be.true;
+      expect(outdated.current.value).to.deep.equal(bar);
+      expect(outdated.current.context).to.deep.equal(emptyCntxt);
+      done();
+    });
+  });
+  // TODO(Ian): "should append outdated mutation"
+  it("commit should store a pending mutation into the store", (done) => {
+    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.commit(key, fooVer, foobaz, fooCntxt))
+        .defaultIfEmpty()
+        .flatMap(() => ts.fetch(key))
+        .subscribeOnNext((record: Record) => {
+          expect(record.version.base).to.equal(fooVer.base);
+          expect(record.value).to.deep.equal(foobaz);
+          expect(record.context).to.deep.equal(fooCntxt);
+          done();
+        });
+  });
+  it("commit should emit a pending mutation on the pending stream", (done) => {
+    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.commit(key, fooVer, foobaz, fooCntxt))
+        .subscribeOn(Scheduler.default)
+        .subscribe();
+    ts.pending.take(1).subscribeOnNext((pending: PendingMutation) => {
+      expect(pending.key).to.deep.equal(key);
+      expect(pending.mutation.version.base).to.equal(fooVer.base);
+      expect(pending.mutation.value).to.deep.equal(foobaz);
+      expect(pending.mutation.context).to.deep.equal(fooCntxt);
+      done();
+    });
+  });
+  it("commit should remove the previous mutation, if one exists", (done) => {
+    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.commit(key, fooVer, foobaz, fooCntxt))
+        .subscribeOn(Scheduler.default)
+        .subscribe();
+    ts.pending.take(1)
+        .flatMap((pending: PendingMutation) => {
+          return ts.commit(key, pending.mutation.version, bar, barCntxt)
+              .defaultIfEmpty()
+              .flatMap(() => ts.fetch(key, pending.mutation.version));
         })
         .subscribeOnNext((record: Record) => {
           expect(record).to.be.null;
           done();
         });
   });
-
-  it("should remove the pending mutation associated with a key and base", (done) => {
+  it("commit should throw a KeyNotFoundError for a non-matching key", (done) => {
     var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.commit(key, foobaz, new Version(foobase));
-        })
-        .flatMap((record: Record) => {
-          expect(record).to.not.be.null;
-          return ts.rollback(key, foobase);
-        })
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          var mutation: Version = new Version(foobase).next;
-          return ts.fetch(key, mutation);
-        })
-        .flatMap((record: Record) => {
-          expect(record).to.be.null;
-          return ts.fetch(key);
-        })
-        .subscribeOnNext((record: Record) => {
-          var version: Version = new Version(foobase);
-          expect(record.version.isEqual(version.base, version.sub)).to.be.true;
-          expect(record.value['value']).to.equal('foo');
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.commit(notKey, fooVer, foobaz, fooCntxt))
+        .subscribeOnError((error: KeyNotFoundError) => {
+          expect(error.key).to.deep.equal(notKey);
           done();
         });
   });
-  it("should remove all Records associated with the base, if the provided base is not current",
+  it("commit should throw an outdated target version error for a non-current target version",
      (done) => {
        var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-       ts.push(key, foo, foobase)
-           .flatMap((ok: boolean) => {
-             expect(ok).to.be.true;
-             return ts.commit(key, foobaz, new Version(foobase));
-           })
-           .flatMap((record: Record) => {
-             expect(record).to.not.be.null;
-             return ts.push(key, bar, barbase);
-           })
-           .subscribeOnError((error: StoreError) => {
-             ts.rollback(key, foobase)
-                 .flatMap((ok: boolean) => {
-                   expect(ok).to.be.true;
-                   return ts.fetch(key, new Version(foobase));
-                 })
-                 .flatMap((record: Record) => {
-                   expect(record).to.be.null;
-                   var mutationVersion: Version = new Version(foobase).next;
-                   return ts.fetch(key, mutationVersion);
-                 })
-                 .subscribeOnNext((record: Record) => {
-                   expect(record).to.be.null;
-                   done();
-                 });
+       ts.push(key, fooVer.base, foo)
+           .defaultIfEmpty()
+           .flatMap(() => ts.commit(key, notVer, foobaz, fooCntxt))
+           .subscribeOnError((error: OutdatedTargetVersionError) => {
+             expect(error.key).to.deep.equal(key);
+             expect(error.current.isEqual(fooVer)).to.be.true;
+             expect(error.target.isEqual(notVer)).to.be.true;
+             expect(error.mutation).to.deep.equal(foobaz);
+             expect(error.context).to.deep.equal(fooCntxt);
+             done();
            });
      });
-  it("should emit false and not emit any errors for a non-matching key or base", (done) => {
+  it("abandon should remove the pending mutation associated with a specific key and version",
+     (done) => {
+       var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
+       ts.push(key, fooVer.base, foo)
+           .defaultIfEmpty()
+           .flatMap(() => ts.commit(key, fooVer, foobaz, {}))
+           .subscribeOn(Scheduler.default)
+           .subscribe();
+       ts.pending.take(1)
+           .flatMap((pending: PendingMutation) => {
+             return ts.abandon(key, pending.mutation.version)
+                 .defaultIfEmpty()
+                 .flatMap(() => ts.fetch(key, pending.mutation.version));
+           })
+           .flatMap((record: Record) => {
+             expect(record).to.be.null;
+             return ts.fetch(key);
+           })
+           .subscribeOnNext((record: Record) => {
+             expect(record.version.isEqual(fooVer)).to.be.true;
+             expect(record.value).to.deep.equal(foo);
+             expect(record.context).to.deep.equal(emptyCntxt);
+             done();
+           });
+     });
+  it("abandon should throw an InvalidInitialTargetVersionError, if provided an initial version",
+     (done) => {
+       var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
+       ts.push(key, fooVer.base, foo)
+           .defaultIfEmpty()
+           .flatMap(() => ts.abandon(key, fooVer))
+           .subscribeOnError((error: InvalidInitialTargetVersionError) => {
+             expect(error.key).to.deep.equal(key);
+             expect(error.target.isEqual(fooVer)).to.be.true;
+             done();
+           });
+     });
+  it("abandon should remove all Records associated with the version, if the provided version is not current",
+     (done) => {
+       var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
+       ts.push(key, fooVer.base, foo)
+           .defaultIfEmpty()
+           .flatMap(() => ts.commit(key, fooVer, foobaz, fooCntxt))
+           .defaultIfEmpty()
+           .flatMap(() => ts.push(key, barVer.base, bar))
+           .subscribeOn(Scheduler.default)
+           .subscribe();
+       ts.outdated.take(1)
+           .flatMap((outdated: OutdatedMutation) => {
+             return ts.abandon(key, outdated.mutation.version)
+                 .defaultIfEmpty()
+                 .flatMap(() => ts.fetch(key, outdated.mutation.version));
+           })
+           .flatMap((record: Record) => {
+             expect(record).to.be.null;
+             return ts.fetch(key, fooVer);
+           })
+           .subscribeOnNext((record: Record) => {
+             expect(record).to.be.null;
+             done();
+           });
+     });
+  it("abandon should throw a KeyNotFoundError for a non-matching key", (done) => {
     var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.rollback(notkey, foobase);
-        })
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.false;
-          return ts.rollback(key, notbase);
-        })
-        .subscribeOnNext((ok: boolean) => {
-          expect(ok).to.be.false;
+    ts.push(key, fooVer.base, foo)
+        .defaultIfEmpty()
+        .flatMap(() => ts.commit(key, fooVer, foobaz, fooCntxt))
+        .subscribeOn(Scheduler.default)
+        .subscribe();
+    ts.pending.take(1)
+        .flatMap((pending: PendingMutation) => ts.abandon(notKey, pending.mutation.version))
+        .subscribeOnError((error: KeyNotFoundError) => {
+          expect(error.key).to.deep.equal(notKey);
           done();
         });
   });
-
-  it("should emit pending mutations", (done) => {
-    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.commit(key, foobaz, new Version(foobase));
-        })
-        .flatMap((record: Record) => {
-          expect(record).to.not.be.null;
-          return ts.pending();
-        })
-        .subscribeOnNext((record: Record) => {
-          expect(record.value['value']).to.equal('foobaz');
-          done();
-        });
-  });
-  it("should throw deperecated mutation errors when checking for pending mutations", (done) => {
-    var ts: TacticalStore = new TacticalStore(InMemoryIdbFactory);
-    ts.push(key, foo, foobase)
-        .flatMap((ok: boolean) => {
-          expect(ok).to.be.true;
-          return ts.commit(key, foobaz, new Version(foobase));
-        })
-        .flatMap((record: Record) => {
-          expect(record).to.not.be.null;
-          return ts.push(key, bar, barbase);
-        })
-        .subscribeOnError((error: StoreError) => {
-          ts.pending().subscribeOnError((otherError: ErrorDM) => {
-            var mutversion: Version = new Version(foobase).next;
-            expect(otherError.type).to.equal(StoreErrorType.DeprecatedMutation);
-            expect(otherError.initial.value['value']).to.equal('foo');
-            expect(otherError.mutation.value['value']).to.equal('foobaz');
-            expect(otherError.current.value['value']).to.equal('bar');
-            done();
-          });
-        });
-  });
-
 });

--- a/tsd.json
+++ b/tsd.json
@@ -14,56 +14,62 @@
     "chai/chai.d.ts": {
       "commit": "6387999eb899d0ba02d37dd8697647718caca230"
     },
-    "rx/rx.all.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
+    "rx/rx-lite.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
     },
-    "rx/rx.backpressure-lite.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.backpressure.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.aggregates.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.binding.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.async.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.joinpatterns.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.experimental.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.lite.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.async-lite.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.virtualtime.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.testing.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.time.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
-    },
-    "rx/rx.binding-lite.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
+    "rx/rx.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
     },
     "rx/rx.time-lite.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.time.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.async.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.all.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.binding.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.aggregates.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.binding-lite.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.async-lite.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
     },
     "rx/rx.coincidence-lite.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
     },
     "rx/rx.coincidence.d.ts": {
-      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.joinpatterns.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.experimental.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.virtualtime.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.backpressure.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.testing.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.lite.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
+    },
+    "rx/rx.backpressure-lite.d.ts": {
+      "commit": "b2345aee407127928f247165c91e18bd7dc1a14a"
     }
   }
 }


### PR DESCRIPTION
The Store provides two streams that will emit all pending and outdated mutations. Otherwise, Store methods, except for fetch, should either complete or throw an error.